### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -62,5 +62,5 @@ termdates = open('https://raw.githubusercontent.com/everypolitician/everypolitic
 @aphinfo = noko_for('http://data.openaustralia.org/members/websites.xml')
 @wp_link = noko_for('http://data.openaustralia.org/members/wikipedia-commons.xml')
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 scrape_list('http://data.openaustralia.org/members/senators.xml')


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593